### PR TITLE
disabled user/pass from oidc config and e2e from client side

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1346,8 +1346,7 @@ class RoomCreationHandler:
             s.get("type", "") == EventTypes.RoomEncryption for s in raw_initial_state
         )
 
-        if preset_config["encrypted"] or room_encryption_event:
-            raise SynapseError(400, "You cannot create an encrypted room.")
+        if preset_config["encrypted"] or room_encryption_event:            
             if self._default_power_level_content_override:
                 override = self._default_power_level_content_override.get(preset_name)
                 if override is not None:

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -475,8 +475,7 @@ class RegisterRestServlet(RestServlet):
         # Pull out the provided username and do basic sanity checks early since
         # the auth layer will store these in sessions.
         desired_username = None
-        if "username" in body:
-            raise SynapseError(400, "Username/password registration is disabled on this server")
+        if "username" in body:            
             desired_username = body["username"]
             if not isinstance(desired_username, str) or len(desired_username) > 512:
                 raise SynapseError(400, "Invalid username")


### PR DESCRIPTION
reverting because of these things are now covered from client sides and we should keep backend as much as close to upstream we can.